### PR TITLE
fix: replace butanium.github.io URLs with ndif-team.github.io

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       
       - name: Build documentation
         env:
-          SPHINX_HTML_BASEURL: ${{ github.ref == 'refs/heads/main' && 'https://ndif-team.github.io/nnterp/' || 'https://ndif-team.github.io/nnterp/dev/' }}
+          SPHINX_HTML_BASEURL: ${{ github.ref == 'refs/heads/main' && 'https://butanium.github.io/nnterp/' || 'https://butanium.github.io/nnterp/dev/' }}
         run: |
           cd docs
           uv run make html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       
       - name: Build documentation
         env:
-          SPHINX_HTML_BASEURL: ${{ github.ref == 'refs/heads/main' && 'https://butanium.github.io/nnterp/' || 'https://butanium.github.io/nnterp/dev/' }}
+          SPHINX_HTML_BASEURL: ${{ github.ref == 'refs/heads/main' && 'https://ndif-team.github.io/nnterp/' || 'https://ndif-team.github.io/nnterp/dev/' }}
         run: |
           cd docs
           uv run make html

--- a/docs/README_BEFORE_EDITING_THE_DOC.md
+++ b/docs/README_BEFORE_EDITING_THE_DOC.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `nnterp` documentation is built using Sphinx with the PyData theme and hosted on GitHub Pages at https://butanium.github.io/nnterp/. The docs present `nnterp` as a nnsight wrapper specifically for transformer models, providing a standardized interface across architectures.
+The `nnterp` documentation is built using Sphinx with the PyData theme and hosted on GitHub Pages at https://ndif-team.github.io/nnterp/. The docs present `nnterp` as a nnsight wrapper specifically for transformer models, providing a standardized interface across architectures.
 
 ## Configuration (conf.py)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ html_sourcelink_suffix = ".txt"
 # Important for GitHub Pages
 # Allow override via environment variable for dev/staging deployments
 html_baseurl = os.environ.get(
-    "SPHINX_HTML_BASEURL", "https://butanium.github.io/nnterp/"
+    "SPHINX_HTML_BASEURL", "https://ndif-team.github.io/nnterp/"
 )
 html_extra_path = [".nojekyll", "llms.txt"]
 
@@ -57,7 +57,7 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "GitHub",
-            "url": "https://github.com/butanium/nnterp",
+            "url": "https://github.com/ndif-team/nnterp",
             "icon": "fa-brands fa-github",
         },
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ vllm = [
     "vllm",
 ]
 [project.urls]
-"Homepage" = "https://github.com/butanium/nnterp"
+"Homepage" = "https://github.com/ndif-team/nnterp"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Fix all references to the old GitHub Pages URL across docs config, workflow, and package metadata.

Closes #43

Generated with [Claude Code](https://claude.ai/code)