### PR TITLE
Ship nnterp/data/ in built wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ include-package-data = true
 
 [tool.setuptools.package-data]
 nnterp = ["py.typed"]
-"*" = ["tests/*"]
+"*" = ["tests/*", "data/*"]
 
 [tool.coverage.run]
 omit = ["nnterp/tests/*"]


### PR DESCRIPTION
package-data globs tests/* but not data/*, and nnterp.data is a namespace subpackage not listed in [tool.setuptools] packages, so nnterp/data/ is dropped from built wheels (both the PyPI wheel and any `pip install git+…`/uv build). As a result `python -m nnterp run_tests` crashes on import — nnterp/tests/utils.py resolves importlib.resources.files("nnterp.data") at module load — and any consumer importing nnterp.data fails with ModuleNotFoundError.

Add data/* to the package-data glob. Verified: a wheel built with this change ships nnterp/data/status.json, importlib.resources.files("nnterp.data") resolves, and nnterp.tests.utils imports cleanly.